### PR TITLE
Fix baseURL references for PR site previews

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://cnab.io/"
+baseURL = "https://cnab.io"
 title = "CNAB - Cloud Native Application Bundle"
 theme = "cnab"
 languageCode = "en-us"

--- a/themes/cnab/layouts/_default/single.html
+++ b/themes/cnab/layouts/_default/single.html
@@ -13,7 +13,7 @@
     {{ if .Params.tags }}
     <ul class="post-tags">
       {{ range .Params.tags }}
-      <li><a href="{{$.Site.BaseURL}}tags/{{ . | urlize }}/">{{ . }}</a></li>
+      <li><a href="{{.Site.BaseURL}}/tags/{{ . | urlize }}/">{{ . }}</a></li>
       {{ end }}
     </ul>
     {{ end }}

--- a/themes/cnab/layouts/partials/header.html
+++ b/themes/cnab/layouts/partials/header.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.LanguageCode }}">
-  
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  
+
   <title>CNAB: Cloud Native Application Bundles</title>
-  
+
   <!-- Meta -->
   {{- if eq .Kind "page" }}
   <meta name="description" content="{{ .Summary }}">
@@ -25,17 +25,17 @@
    <meta name="twitter:description" content="Cloud Native Application Bundles facilitate the bundling, installing and managing of container-native apps — and their coupled services.">
    <meta name="twitter:image" content="https://cnab.io/img/twitter-card.png">
    <meta name="twitter:image:alt" content="CNAB: a spec for packaging distributed apps.">
-  
+
   <!-- Styles -->
-  <link href="{{.Site.BaseURL}}css/styles.min.css" rel="stylesheet">
-  
+  <link href="{{.Site.BaseURL}}/css/styles.min.css" rel="stylesheet">
+
   <!-- Icons -->
   <link rel="icon" type="image/png" href="static/img/favicon.png">
   <link rel="apple-touch-icon" href="static/img/touch-icon-iphone-60x60.png">
   <link rel="apple-touch-icon" sizes="60x60" href="static/img/touch-icon-ipad-76x76.png">
   <link rel="apple-touch-icon" sizes="114x114" href="static/img/touch-icon-iphone-retina-120x120.png">
   <link rel="apple-touch-icon" sizes="144x144" href="static/img/touch-icon-ipad-retina-152x152.png">
-  <link rel="icon" href="{{.Site.BaseURL}}img/favicon.ico">
+  <link rel="icon" href="{{.Site.BaseURL}}/img/favicon.ico">
 
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -44,26 +44,26 @@
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
   })(window,document,'script','dataLayer','GTM-PQVQPKP');</script>
   <!-- End Google Tag Manager -->
-  
+
   <!-- Generator -->
   {{ .Hugo.Generator }}
   <!-- RSS -->
-  <link rel="alternate" type="application/atom+xml" href="{{.Site.BaseURL}}index.xml" title="{{ .Site.Title }}">
+  <link rel="alternate" type="application/atom+xml" href="{{.Site.BaseURL}}/index.xml" title="{{ .Site.Title }}">
   {{ if eq (getenv "HUGO_ENV") "production" | or (eq .Site.Params.env "production")  }}
     {{ template "_internal/google_analytics_async.html" . }}
   {{ end }}
 </head>
 
 <body class="{{if eq .Kind `page` }}single{{else}}list{{ if .IsHome }} home{{ end }}{{end}}">
-  
+
     <header class="header row row-full">
       <div class="show-for-large-up large-1 columns"></div>
       <div class="small-6 large-4 columns">
         <h1 class=""><a href="{{.Site.BaseURL}}">
-          <img src="{{.Site.BaseURL}}img/cnab-text.svg" class="logo" alt="Cloud Native Application Bundle" /> 
+          <img src="{{.Site.BaseURL}}/img/cnab-text.svg" class="logo" alt="Cloud Native Application Bundle" />
         </a></h1>
       </div>
-  
+
       <!-- desktop menu-->
       <nav class="large-4 columns end">
         <ul class="inline-list right show-for-large-up menu-desktop">
@@ -71,7 +71,7 @@
         </ul>
       </nav>
       <div class="show-for-large-up large-1 columns"></div>
-      
+
       <!-- mobile menu-->
       <button class="menu-toggle hide-for-large-up columns" type="button"></button>
       <nav class="menu">


### PR DESCRIPTION
When we substitute the base url for a netlify preview, it doesn't have a trailing `/`, so the urls are broken. I liked doing the fix this way, vs. shoving in a `/` in the makefile, because then we didn't have funky looking concatenation like `{baseurl}images`. 

It does seem to fix the preview and not break the main site. 🤞 