### PR TITLE
Fix Pivotal URL in main page

### DIFF
--- a/themes/cnab/layouts/index.html
+++ b/themes/cnab/layouts/index.html
@@ -135,7 +135,7 @@
         <div class="text-center">
           <a href="https://azure.microsoft.com" target="_blank"><img src="../img/logo-azure.png" /></a>
           <a href="https://www.docker.com/" target="_blank"><img src="../img/logo-docker.png" /></a>
-          <a href="https://www.pivotal.com/" target="_blank"><img src="../img/logo-pivotal.png" /></a>
+          <a href="https://www.pivotal.io/" target="_blank"><img src="../img/logo-pivotal.png" /></a>
           <a href="https://bitnami.com/" target="_blank"><img src="../img/logo-bitnami.png" /></a>
           <a href="https://www.hashicorp.com/" target="_blank"><img src="../img/logo-hashicorp.png" /></a>
           <a href="https://www.codefresh.io/" target="_blank"><img src="../img/logo-codefresh.png" /></a>


### PR DESCRIPTION
As @glyn pointed out, the URL on the main page does not point to `pivotal.io`, which is the right URL for the Pivotal main page. This PR fixes that.