### PR TITLE
Add CNAB resources page

### DIFF
--- a/content/resources.md
+++ b/content/resources.md
@@ -1,0 +1,28 @@
+---
+title: Resources
+description: External videos, blog posts and tutorials about CNAB
+---
+
+Do you have a blog post, video, tutorial, demo, or some other neat thing 
+using CNAB that you'd like to share? Send us a pull request!
+
+* [The First Bundle](#the-first-bundle) 
+* [Bringing container magic to cloud-native applications](#bringing-container-magic-to-cloud-native-applications)
+* [Cloud Native Application Bundles: A Simple Way to Install Software on Kubernetes (or Any Other Runtime)](#cloud-native-application-bundles-a-simple-way-to-install-software-on-kubernetes-or-any-other-runtime)
+
+## The First Bundle
+Footage of the first bespoke bundle coming into existance.
+
+![man shoving clothes into a bag with his foot](/img/how-to-make-a-bundle.gif)
+
+## Bringing container magic to cloud-native applications
+
+Last year at Microsoft Connect and DockerCon we announced the Cloud Native Application Bundle (CNAB) specification in partnership with Docker, HashiCorp, and Bitnami. Since then the CNAB community has grown to include Pivotal, Intel, Datadog, and others, and we are all extremely pleased to announce that the CNAB core 1.0 specification has reached Final Draft [Read More][2]
+
+[2]: https://cloudblogs.microsoft.com/opensource/2019/09/10/cloud-native-application-bundle-cnab-1-0-updates
+
+## Cloud Native Application Bundles: A Simple Way to Install Software on Kubernetes (or Any Other Runtime)
+
+CNAB is a cloud-agnostic package format specification for bundling and installing distributed applications. [This post][1] explains the project, describes technical specs & how Pivotal is using it today.
+
+[1]: https://content.pivotal.io/blog/cloud-native-application-bundles-a-simple-way-to-install-software-on-kubernetes-or-any-other-runtime

--- a/themes/cnab/layouts/partials/nav.html
+++ b/themes/cnab/layouts/partials/nav.html
@@ -1,4 +1,5 @@
 <li><a href="https://github.com/deislabs/cnab-spec">The Spec</a></li>
 <li><a href="/community-projects">Community Projects</a></li>
+<li><a href="/resources">Resources</a></li>
 <li><a href="/community-meetings">Meetings</a></li>
 <li><a href="https://github.com/deislabs/cnab-spec" target="_blank"><i class="fa fa-github" aria-hidden="true"></i></a></li>


### PR DESCRIPTION
A glorious page for gifs, demos, talks, and blog posts about CNAB

Preview available at https://deploy-preview-18--cnabio.netlify.com/resources/